### PR TITLE
Add new cypress command to add IAP headers w/o a cy.visit. 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+declare namespace Cypress {
+    interface Chainable<Subject> {
+        /**
+         * Add IAP Proxy-Authorization header w/o a cy.visit
+         * Use in a beforeEach() hook if the app is not reloaded between tests
+         */
+         manualAddIAPHeader(): Chainable<any>
+    }
+}

--- a/manualAddIAPHeader.js
+++ b/manualAddIAPHeader.js
@@ -1,0 +1,24 @@
+/// <reference types="cypress">
+Cypress.Commands.add("manualAddIAPHeader", () => {
+    if (Cypress.config().baseUrl.indexOf("localhost") != -1) {
+        return
+    } else {
+        cy.exec(
+            `curl -I ${Cypress.config().baseUrl
+            } | awk '/^location/ {split($NF, a, /[=&]/); print a[2]}'`
+        )
+            .then((client_id) => {
+                return client_id.stdout;
+            })
+            .then((client_id) => {
+                cy.task("getIAPToken", {
+                    url: Cypress.config().baseUrl,
+                    cid: client_id,
+                }).then((iapToken) => {
+                    cy.intercept(`${Cypress.config().baseUrl}/**`, (req) => {
+                        req.headers["Proxy-Authorization"] = `${iapToken}`;
+                    })
+                })
+            })
+    }
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-iap",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Cypress command to authenticate to Google Identity Aware Proxy(IAP)",
   "main": "index.js",
   "types": "index.d.ts",
@@ -9,6 +9,7 @@
   "files": [
     "visit.js",
     "utils.js",
+    "manualAddIAPHeader.js",
     "index.d.ts"
   ],
   "scripts": {


### PR DESCRIPTION
Basically a carbon copy of the overwritten command.
Adds the index.d.ts so I can export this command and not let vscode complain.

Full disclosure: Adding a new cypress command in a submodule is fresh territory for me, so I'm sure I did something dumb here.
This is just a stab at getting us unblocked.

# Open Questions:
- Do I need to update `package-lock.json`? I only did `package.json`
- Should I clean up this code and find a way to reuse stuff between `visit.js` and the new `manualAddIAPHeader.js`?
- Does this PR make me look fat?

# Testing comments:
- I manually inserted these changes into `/node-modules` in my app's repo.
Would "be nice" to actually test pulling this, but I'm not smart enough to setup a specific branch like that as an npm depencency.